### PR TITLE
quizbook 업데이트 로직추가 

### DIFF
--- a/src/entity/quiz-book.entity.ts
+++ b/src/entity/quiz-book.entity.ts
@@ -33,6 +33,9 @@ export class QuizBookEntity {
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   createdAt: Date;
 
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+
   @Column({ type: 'int', default: 0 })
   likedCount: number;
 

--- a/src/entity/user-solve-quiz-book.entity.ts
+++ b/src/entity/user-solve-quiz-book.entity.ts
@@ -32,6 +32,9 @@ export class UserSolveQuizBookEntity {
   @Column({ type: 'int', nullable: false })
   quizBookId: number;
 
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+
   @ManyToOne((type) => UserEntity, (user) => user.solves, { nullable: false })
   @JoinColumn({ name: 'userId', referencedColumnName: 'id' })
   user: UserEntity;

--- a/src/quiz-book/quiz-book.service.ts
+++ b/src/quiz-book/quiz-book.service.ts
@@ -264,6 +264,8 @@ export class QuizBookService {
       .catch(() => {
         throw new BadRequestException('잘못된 요청입니다.');
       });
+
+    await this.syncQuizBookUpdatedAt(quizBookId);
   }
 
   async solveQuizBook(
@@ -365,5 +367,11 @@ export class QuizBookService {
       quizBook[0],
       quizBook[0].allSolved,
     );
+  }
+
+  async syncQuizBookUpdatedAt(quizBookId: number) {
+    const quizBook = await this.quizBookRepository.findOne({ id: quizBookId });
+    quizBook.updatedAt = new Date();
+    await this.quizBookRepository.save(quizBook);
   }
 }

--- a/src/user-solve-quiz-book/user-solve-quiz-book.service.ts
+++ b/src/user-solve-quiz-book/user-solve-quiz-book.service.ts
@@ -138,7 +138,7 @@ export class UserSolveQuizBookService {
         solvedQuizBook.savedCorrectCount += 1;
       }
       if (isLastQuiz) quizBook.solvedCount += 1;
-
+      solvedQuizBook.updatedAt = new Date();
       solvedQuizBook.savedQuizId = solvedQuizBookDTO.quizId;
     }
 


### PR DESCRIPTION
-  quizbook에서 quiz삭제시 기존의 퀴즈북을 풀고 있던 유저들이 해당 퀴즈북을 이어풀 때 정답율에 오류가 생기는 것을 막기 위하여 updatedAt column을 quizbook과 userSolveQuizBook table에 추가
- quizbook 에서 quiz 삭제시 updatedAt 업데이트
- user가 quiz를 풀때마다 userSolveBook updatedAt 업데이트